### PR TITLE
WP-9269 Fix tap-redshift build problems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,11 @@ tap-redshift
 `Singer <https://singer.io>`_ tap that extracts data from a `Redshift <https://aws.amazon.com/documentation/redshift/>`_ database and produces JSON-formatted data following the Singer spec.
 
 
+Forked to symon-ai/tap-redshift to fix build problems
+=====================================================
+* tap-redshift could not find ``pytz`` library. Solved by naming ``pytz`` in setup.py.
+* tap-redshift could not find path to ``pg_config``. Solved by importing ``psycopg2-binary`` instead of ``psycopg2``.
+
 Usage
 =====
 tap-redshift assumes you have a connection to Redshift and requires Python 3.6+.

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,7 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-        # 'psycopg2==2.7.3.2',
-        'psycopg2==2.9.3',
+        'psycopg2==2.7.3.2',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'singer-python==5.0.4',
         'backoff==1.3.2',
         'psycopg2-binary',
+        'pytz>=2021.3',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',
@@ -64,7 +65,6 @@ setup(
         'flake8>=2.6.0,<3.4.1a',
         'pyhamcrest>=1.9.0,<2.0a',
         'pytest>=3.2.3,<4.0a',
-        'pytz>=2021.3',
       ],
       entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-        'psycopg2-binary==2.7.3.2',
+        'psycopg2-binary==2.7.4',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-          'psycopg2==2.7.4',
+        'psycopg2==2.7.4',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-        'psycopg2==2.7.3.2',
+        'psycopg2-binary==2.7.3.2',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-        'psycopg2-binary',
-        'pytz>=2021.3',
+        'psycopg2-binary==2.9.3',
+        'pytz==2021.3',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-        'psycopg2==2.7.4',
+        'psycopg2-binary==2.7.3.2',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-        # 'psycopg2==2.7.3.2',
+          'psycopg2==2.7.4',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-        'psycopg2==2.7.3.2',
+        # 'psycopg2==2.7.3.2',
+        'psycopg2==2.9.3',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-        'psycopg2-binary==2.7.4',
+        'psycopg2-binary',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'flake8>=2.6.0,<3.4.1a',
         'pyhamcrest>=1.9.0,<2.0a',
         'pytest>=3.2.3,<4.0a',
+        'pytz>=2021.3',
       ],
       entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum==1.2.0',
         'singer-python==5.0.4',
         'backoff==1.3.2',
-        'psycopg2-binary==2.7.3.2',
+        # 'psycopg2==2.7.3.2',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -16,7 +16,7 @@ from singer.catalog import Catalog, CatalogEntry
 from singer.schema import Schema
 from tap_redshift import resolve
 
-__version__ = '1.0.0b9'
+__version__ = '1.0.0b9-symon-ai'
 
 LOGGER = singer.get_logger()
 


### PR DESCRIPTION
# Description of change
[WP-9269 Fork singer-io/tap-redshift to fix build problems](https://varicent.atlassian.net/browse/WP-9269)

- tap-redshift could not find ``pytz`` library. Solved by naming ``pytz`` in setup.py.
- tap-redshift could not find path to ``pg_config``. Solved by importing ``psycopg2-binary`` instead of ``psycopg2``.

# Manual QA steps
 - None for this card, which covers fixing the build for the tap-redshift module. This module will be tested with [WP-7629](https://varicent.atlassian.net/browse/WP-7629)
 
# Risks
 - Nothing special. The tap-redshift module was not previously used by Symon.
 
# Rollback steps
 - revert this branch
