### PR TITLE
WP-9885 Amazon redshift import returns columns in random order

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -482,11 +482,10 @@ def build_state(raw_state, catalog):
 def get_column_orders():
     parser = argparse.ArgumentParser()
 
+    # Only added arguments needed for running extraction command.
     parser.add_argument('-c', '--config')
-    parser.add_argument('-s', '--state')
     parser.add_argument('-p', '--properties')
     parser.add_argument('--catalog')
-    parser.add_argument('-d', '--discover')
 
     args = parser.parse_args()
 
@@ -509,17 +508,18 @@ def get_column_orders():
 @utils.handle_top_exception(LOGGER)
 def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
-    column_order_map = get_column_orders()
     CONFIG.update(args.config)
     connection = open_connection(args.config)
     db_schema = args.config.get('schema') or 'public'
     if args.discover:
         do_discover(connection, db_schema)
     elif args.catalog:
+        column_order_map = get_column_orders()
         setattr(args.catalog, 'column_order_map', column_order_map)
         state = build_state(args.state, args.catalog)
         do_sync(connection, db_schema, args.catalog, state)
     elif args.properties:
+        column_order_map = get_column_orders()
         catalog = Catalog.from_dict(args.properties)
         setattr(catalog, 'column_order_map', column_order_map)
         state = build_state(args.state, catalog)

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -495,7 +495,7 @@ def get_column_orders():
 
     if args.catalog:
         catalog = load_json(args.catalog)
-    elif args.properties:
+    else:
         catalog = load_json(args.properties)
 
     column_order_map = {}

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -4,6 +4,7 @@ import pytz
 import ssl
 import sys
 import time
+import argparse
 from itertools import groupby
 
 import pendulum

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -110,24 +110,28 @@ def discover_catalog(conn, db_schema):
             db_name, db_schema, cols, is_view, key_properties)
         tap_stream_id = '{}.{}'.format(
             db_name, qualified_table_name)
-        entry = CatalogEntry(
-            tap_stream_id=tap_stream_id,
-            stream=table_name,
-            schema=schema,
-            table=qualified_table_name,
-            metadata=metadata)
+        entry = {
+            'tap_stream_id': tap_stream_id,
+            'table_name': qualified_table_name,
+            'schema': schema.to_dict(),
+            'stream': table_name,
+            'metadata': metadata,
+            'column_order': [str(column) for column in schema.properties]
+        }
 
         entries.append(entry)
 
-    return Catalog(entries)
+    catalog = {'streams': entries}
+
+    return catalog
 
 
 def do_discover(conn, db_schema):
     LOGGER.info("Running discover")
     catalog = discover_catalog(conn, db_schema)
-    if len(catalog.streams) == 0:
+    if len(catalog['streams']) == 0:
         raise Exception("Discovered no tables. Check your user's permissions and schema configuration value and try again.")
-    catalog.dump()
+    json.dump(catalog, sys.stdout, indent=4)
     LOGGER.info("Completed discover")
 
 
@@ -474,19 +478,49 @@ def build_state(raw_state, catalog):
     return state
 
 
+def get_column_orders():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-c', '--config')
+    parser.add_argument('-s', '--state')
+    parser.add_argument('-p', '--properties')
+    parser.add_argument('--catalog')
+    parser.add_argument('-d', '--discover')
+
+    args = parser.parse_args()
+
+    def load_json(path):
+        with open(path) as fil:
+            return json.load(fil)
+
+    if args.catalog:
+        catalog = load_json(args.catalog)
+    elif args.properties:
+        catalog = load_json(args.properties)
+
+    column_order_map = {}
+    for catalog_entry in catalog['streams']:
+        column_order_map[catalog_entry['stream']] = catalog_entry['column_order']
+
+    return column_order_map
+
+
 @utils.handle_top_exception(LOGGER)
 def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
+    column_order_map = get_column_orders()
     CONFIG.update(args.config)
     connection = open_connection(args.config)
     db_schema = args.config.get('schema') or 'public'
     if args.discover:
         do_discover(connection, db_schema)
     elif args.catalog:
+        setattr(args.catalog, 'column_order_map', column_order_map)
         state = build_state(args.state, args.catalog)
         do_sync(connection, db_schema, args.catalog, state)
     elif args.properties:
         catalog = Catalog.from_dict(args.properties)
+        setattr(catalog, 'column_order_map', column_order_map)
         state = build_state(args.state, catalog)
         do_sync(connection, db_schema, catalog, state)
     else:

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -76,6 +76,12 @@ def resolve_catalog(discovered, catalog, state):
 
     result = Catalog(streams=[])
 
+    # Return type of discover_catalog has been changed from Catalog class to dict.
+    # Cast it back to Catalog class
+    discovered = Catalog.from_dict(discovered)
+    # Order of columns for each stream
+    column_order_map = catalog.column_order_map
+
     # Iterate over the streams in the input catalog and match each one up
     # with the same stream in the discovered catalog.
     for catalog_entry in streams:
@@ -89,7 +95,7 @@ def resolve_catalog(discovered, catalog, state):
 
         # These are the columns we need to select
         columns = desired_columns(selected, discovered_table.schema)
-        ordered_columns = list(filter(lambda x: x in columns, catalog_entry.schema.properties.keys()))
+        ordered_columns = list(filter(lambda x: x in columns, column_order_map[catalog_entry.stream]))
 
         schema = Schema(
             type='object',


### PR DESCRIPTION
WP-9885 Amazon redshift import returns columns in random order
https://varicent.atlassian.net/browse/WP-9885

notes:
- added fix to use column_order property when determining order of columns