### PR TITLE
WP-9728 Fix obfuscate

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -17,7 +17,7 @@ from singer.catalog import Catalog, CatalogEntry
 from singer.schema import Schema
 from tap_redshift import resolve
 
-__version__ = '1.0.0b10-symon-ai'
+__version__ = '1.0.0b11-symon-ai'
 
 LOGGER = singer.get_logger()
 
@@ -261,7 +261,7 @@ def row_to_record(catalog_entry, version, row, columns, time_extracted):
             elem = elem.isoformat('T') + 'Z'
         row_to_persist += (elem,)
     return singer.RecordMessage(
-        stream=catalog_entry.stream,
+        stream=catalog_entry.tap_stream_id,
         record=dict(zip(columns, row_to_persist)),
         version=version,
         time_extracted=time_extracted)
@@ -305,7 +305,7 @@ def sync_table(connection, catalog_entry, state):
             stream_version
         )
         activate_version_message = singer.ActivateVersionMessage(
-            stream=catalog_entry.stream,
+            stream=catalog_entry.tap_stream_id,
             version=stream_version
         )
 
@@ -396,7 +396,7 @@ def generate_messages(conn, db_schema, catalog, state):
 
         # Emit a SCHEMA message before we sync any records
         yield singer.SchemaMessage(
-            stream=catalog_entry.stream,
+            stream=catalog_entry.tap_stream_id,
             schema=catalog_entry.schema.to_dict(),
             key_properties=key_properties,
             bookmark_properties=bookmark_properties)

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -88,7 +88,7 @@ def discover_catalog(conn, db_schema):
     table_columns = [{'name': k, 'columns': [
         {'pos': t[1], 'name': t[2], 'type': t[3],
          'nullable': t[4]} for t in v]}
-                     for k, v in groupby(column_specs, key=lambda t: t[0])]
+        for k, v in groupby(column_specs, key=lambda t: t[0])]
 
     table_pks = {k: [t[1] for t in v]
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
@@ -131,7 +131,8 @@ def do_discover(conn, db_schema):
     LOGGER.info("Running discover")
     catalog = discover_catalog(conn, db_schema)
     if len(catalog['streams']) == 0:
-        raise Exception("Discovered no tables. Check your user's permissions and schema configuration value and try again.")
+        raise Exception(
+            "Discovered no tables. Check your user's permissions and schema configuration value and try again.")
     json.dump(catalog, sys.stdout, indent=4)
     LOGGER.info("Completed discover")
 
@@ -500,7 +501,8 @@ def get_column_orders():
 
     column_order_map = {}
     for catalog_entry in catalog['streams']:
-        column_order_map[catalog_entry['stream']] = catalog_entry['column_order']
+        column_order_map[catalog_entry['stream']
+                         ] = catalog_entry['column_order']
 
     return column_order_map
 


### PR DESCRIPTION
# Description of change
The keys for the `columnToMask` map need to be "tap_stream_id" instead of "stream", for use by `ExtractToCsvWorker`. 

Followed same approach as [WP-9223](https://varicent.atlassian.net/browse/WP-9223) used for tap-mysql.

# Manual QA steps
 - Import tables from a Redshift server, and specify some of the columns to be "obfuscated".
 
# Risks
 - Could break imports from Redshift servers.
 
# Rollback steps
 - revert this branch
