### PR TITLE
WP-10684 Remove __version__ string

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -17,8 +17,6 @@ from singer.catalog import Catalog, CatalogEntry
 from singer.schema import Schema
 from tap_redshift import resolve
 
-__version__ = '1.0.1'
-
 LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [


### PR DESCRIPTION
This is no longer used. Should have been removed with other poetry changes.