### PR TITLE
WP-28262: Update tap and target repos: veracode/veracode-uploadandscan-action@0.2.6 to 0.2.11

### DIFF
--- a/.github/workflows/veracode-static-scan.yml
+++ b/.github/workflows/veracode-static-scan.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get timestamp
         run: echo TIMESTAMP=$(date +%Y-%m-%d_%H:%M:%S) >> $GITHUB_ENV
       - name: Veracode Upload And Scan
-        uses: veracode/veracode-uploadandscan-action@0.2.6
+        uses: veracode/veracode-uploadandscan-action@0.2.11
         with:
           appname: ELT_tap-redshift
           createprofile: true


### PR DESCRIPTION
https://varicent.atlassian.net/browse/WP-28262